### PR TITLE
Support local (capacitor) filepaths, instead of base64 string

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ export class SignupComponent {
     downloadButtonClick() {
         FileSharer.share({
             filename: "test.pdf",
-            base64Data: "...",
             contentType: "application/pdf",
+            // If you want to save base64:
+            base64Data: "...",
+            // If you want to save a file from a path:
+            path: "../../file.pdf",
         }).then(() => {
             // do sth
         }).catch(error => {

--- a/android/src/main/java/com/byteowls/capacitor/filesharer/FileSharerPlugin.java
+++ b/android/src/main/java/com/byteowls/capacitor/filesharer/FileSharerPlugin.java
@@ -15,9 +15,14 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
 import java.util.Objects;
 
 @CapacitorPlugin(name = "FileSharer")
@@ -28,6 +33,7 @@ public class FileSharerPlugin extends Plugin {
     private static final String PARAM_FILENAME = "filename";
     private static final String PARAM_CONTENT_TYPE = "contentType";
     private static final String PARAM_BASE64_DATA = "base64Data";
+    private static final String PARAM_LOCAL_PATH = "path";
     private static final String PARAM_ANDROID_CHOOSER = "android.titlechooser";
 
     private static final String ERR_PARAM_NO_FILENAME = "ERR_PARAM_NO_FILENAME";
@@ -35,6 +41,7 @@ public class FileSharerPlugin extends Plugin {
     private static final String ERR_PARAM_NO_DATA = "ERR_PARAM_NO_DATA";
     private static final String ERR_FILE_CACHING_FAILED = "ERR_FILE_CACHING_FAILED";
     private static final String ERR_PARAM_DATA_INVALID = "ERR_PARAM_DATA_INVALID";
+    private static final String ERR_LOCAL_FILE_NOT_FOUND = "ERR_LOCAL_FILE_NOT_FOUND";
     private static final String USER_CANCELLED = "USER_CANCELLED";
 
     private String callbackId;
@@ -61,8 +68,24 @@ public class FileSharerPlugin extends Plugin {
 
         String base64Data = ConfigUtils.getParamString(callData, PARAM_BASE64_DATA);
         if (base64Data == null || base64Data.length() == 0) {
-            call.reject(ERR_PARAM_NO_DATA);
-            return;
+            String path = ConfigUtils.getParamString(callData, PARAM_LOCAL_PATH);
+            if (path != null && path.length() > 0) {
+                String[] parts = path.split("_capacitor_file_");
+                if (parts[1] != null) {
+                    path = parts[1];
+                }
+                try {
+                    InputStream is = new FileInputStream(new File(path));
+                    base64Data = readFileAsBase64EncodedData(is);
+                } catch (IOException e) {
+                    Log.e(getLogTag(), e.getMessage());
+                    call.reject(ERR_LOCAL_FILE_NOT_FOUND);
+                    return;
+                }
+            } else {
+                call.reject(ERR_PARAM_NO_DATA);
+                return;
+            }
         }
 
         String chooserTitle = ConfigUtils.getParamString(callData, PARAM_ANDROID_CHOOSER);
@@ -70,6 +93,7 @@ public class FileSharerPlugin extends Plugin {
 
         // save cachedFile to cache dir
         File cachedFile = new File(getCacheDir(), filename);
+
         try (FileOutputStream fos = new FileOutputStream(cachedFile)) {
             byte[] decodedData = Base64.decode(base64Data, Base64.DEFAULT);
             fos.write(decodedData);
@@ -95,6 +119,21 @@ public class FileSharerPlugin extends Plugin {
         sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
         sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivityForResult(call, Intent.createChooser(sendIntent, chooserTitle), "callbackComplete");
+    }
+
+    public String readFileAsBase64EncodedData(InputStream is) throws IOException {
+        FileInputStream fileInputStreamReader = (FileInputStream) is;
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+
+        byte[] buffer = new byte[1024];
+
+        int c;
+        while ((c = fileInputStreamReader.read(buffer)) != -1) {
+            byteStream.write(buffer, 0, c);
+        }
+        fileInputStreamReader.close();
+
+        return Base64.encodeToString(byteStream.toByteArray(), Base64.NO_WRAP);
     }
 
     private File getCacheDir() {

--- a/android/src/main/java/com/byteowls/capacitor/filesharer/FileSharerPlugin.java
+++ b/android/src/main/java/com/byteowls/capacitor/filesharer/FileSharerPlugin.java
@@ -21,8 +21,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
 import java.util.Objects;
 
 @CapacitorPlugin(name = "FileSharer")

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -13,9 +13,13 @@ export interface ShareFileOptions {
      */
     filename: string;
     /**
-     * The base64 encoded data.
+     * The base64 encoded data or capacitor file url.
      */
-    base64Data: string;
+    base64Data?: string;
+    /**
+     * The local path you can find the file
+     */
+    path?: string;
     /**
      * The content type of the provided data.
      */

--- a/src/web.ts
+++ b/src/web.ts
@@ -17,7 +17,7 @@ export class FileSharerPluginWeb extends WebPlugin implements FileSharerPlugin {
 
             let blob = new Blob(
                 [
-                    WebUtils.toByteArray(options.base64Data)
+                    WebUtils.toByteArray(options.base64Data!)
                 ],
                 {
                     type: options.contentType


### PR DESCRIPTION
Android supports receiving a filepath instead of base64 data, and prevents a crash caused by large files