### PR TITLE
chore: remove unsafe import + remove dead code

### DIFF
--- a/android/src/main/java/com/byteowls/capacitor/filesharer/ConfigUtils.java
+++ b/android/src/main/java/com/byteowls/capacitor/filesharer/ConfigUtils.java
@@ -8,7 +8,6 @@ import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Random;
 
 /**
  * @author m.oberwasserlechner@byteowls.com
@@ -116,22 +115,6 @@ public abstract class ConfigUtils {
         Map<String, String> mergedParam = new HashMap<>(baseParam);
         mergedParam.putAll(androidParam);
         return mergedParam;
-    }
-
-    public static String getRandomString(int len) {
-        char[] ch = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-            'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-            'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
-            'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-            'w', 'x', 'y', 'z'};
-
-        char[] c = new char[len];
-        Random random = new Random();
-        for (int i = 0; i < len; i++) {
-            c[i] = ch[random.nextInt(ch.length)];
-        }
-        return new String(c);
     }
 
     public static String trimToNull(String value) {

--- a/android/src/test/java/com/byteowls/capacitor/filesharer/ConfigUtilsTest.java
+++ b/android/src/test/java/com/byteowls/capacitor/filesharer/ConfigUtilsTest.java
@@ -157,13 +157,6 @@ public class ConfigUtilsTest {
     }
 
     @Test
-    public void getRandomString() {
-        String randomString = ConfigUtils.getRandomString(8);
-        Assertions.assertNotNull(randomString);
-        Assertions.assertEquals(8, randomString.length());
-    }
-
-    @Test
     public void empty() {
         // make sure the empty value stays empty
         String emptyValue = ConfigUtils.getParamString(jsObject, "empty");


### PR DESCRIPTION
`java.util.Random` is not a safe way to generate numbers (see: https://www.infosecinstitute.com/resources/application-security/random-number-generation-java/)

I noticed the code wasn't even in use, so I just removed it instead of replacing it with a secure alternative.